### PR TITLE
增加强制重新初始化功能

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -468,8 +468,8 @@ export default class WechatCore {
     return Promise.resolve().then(() => {
       let name, type, size, ext, mediatype, data
       return new Promise((resolve, reject) => {
-        if ((typeof(File) != 'undefined' && file.constructor == File) ||
-          (typeof(Blob) != 'undefined' && file.constructor == Blob)) {
+        if ((typeof (File) !== 'undefined' && file.constructor == File) ||
+          (typeof (Blob) !== 'undefined' && file.constructor == Blob)) {
           name = file.name || 'file'
           type = file.type
           size = file.size

--- a/src/wechat.js
+++ b/src/wechat.js
@@ -164,6 +164,8 @@ class Wechat extends WechatCore {
         this.lastSyncTime = Date.now()
         this.syncPolling()
         this.checkPolling()
+        this.sendMsg('登录成功，退出请向文件传输助手发送\'退出wechat4u\'', 'filehelper')
+          .catch(debug)
       }).catch(err => {
         this.emit('error', err)
         debug(err)
@@ -191,7 +193,7 @@ class Wechat extends WechatCore {
       debug('心跳')
       this.notifyMobile(this.user.UserName)
         .catch(debug)
-      this.sendText('心跳：' + new Date().toLocaleString(), 'filehelper')
+      this.sendMsg('心跳：' + new Date().toLocaleString(), 'filehelper')
         .catch(debug)
       clearTimeout(this.checkPollingId)
       this.checkPollingId = setTimeout(() => {


### PR DESCRIPTION
1. 默认在微信登录时强制重新初始化，真正退出通过向`文件传输助手`发送‘退出wechat4u’
2. 增加同步检测方法，在`syncPolling`长时间挂起时认为登出了微信