### PR TITLE
将初始化接口中的联系人也写入到 bot.contacts 对象中

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -169,7 +169,7 @@ export default class WechatCore {
         this.PROP.skey = data.SKey || this.PROP.skey
         this.updateSyncKey(data)
         Object.assign(this.user, data.User)
-        return this.user
+        return data
       })
     }).catch(err => {
       debug(err)

--- a/src/wechat.js
+++ b/src/wechat.js
@@ -140,7 +140,12 @@ class Wechat extends WechatCore {
 
   _init () {
     return this.init()
-    .then(() => {
+    .then(data => {
+      // this.getContact() 这个接口返回通讯录中的联系人（包括已保存的群聊）
+      // 临时的群聊会话在初始化的接口中可以获取，因此这里也需要更新一遍 contacts
+      // 否则后面可能会拿不到某个临时群聊的信息
+      this.updateContacts(data.ContactList)
+
       this.notifyMobile()
       .catch(err => this.emit('error', err))
       this._getContact()
@@ -208,6 +213,9 @@ class Wechat extends WechatCore {
           return new Promise(resolve => {
             setTimeout(resolve, 60 * 1000)
           }).then(() => this.init())
+            .then(data => {
+              this.updateContacts(data.ContactList)
+            })
         }
       }).catch(err => {
         debug(err)


### PR DESCRIPTION
初始化的接口 https://github.com/Urinx/WeixinBot#微信初始化 也返回了联系人相关信息，将其也写入到 bot.contacts 中