### PR TITLE
Update wechat.js

### DIFF
--- a/src/wechat.js
+++ b/src/wechat.js
@@ -127,6 +127,8 @@ class Wechat extends WechatCore {
         if (emptyGroup.length != 0) {
           return this.batchGetContact(emptyGroup)
           .then(_contacts => contacts = contacts.concat(_contacts || []))
+        } else {
+          return contacts
         }
       } else {
         return contacts


### PR DESCRIPTION
修复一个 异常错误  ：
当 emptyGroup.length = 0  缺少 return，会导致 unhandled promise rejection