### PR TITLE
捕获eval异常

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -326,7 +326,7 @@ export default class WechatCore {
           // eslint-disable-next-line
           eval(res.data)
         } catch (ex) {
-          window.synccheck = {retcode: "0", selector: "0"}
+          window.synccheck = {retcode: '0', selector: '0'}
         }
         assert.equal(window.synccheck.retcode, this.CONF.SYNCCHECK_RET_SUCCESS, res)
 

--- a/src/core.js
+++ b/src/core.js
@@ -322,8 +322,12 @@ export default class WechatCore {
           synccheck: {}
         }
 
-        // eslint-disable-next-line
-        eval(res.data)
+        try {
+          // eslint-disable-next-line
+          eval(res.data)
+        } catch (ex) {
+          window.synccheck = {retcode: "0", selector: "0"}
+        }
         assert.equal(window.synccheck.retcode, this.CONF.SYNCCHECK_RET_SUCCESS, res)
 
         return window.synccheck.selector


### PR DESCRIPTION
有时synccheck接口会返回异常的二进制数据，无法eval，很容易被判定为同步异常然后退出。

这个PR捕获eval的异常，假装同步正常，然后机器人可以继续运行。

和腾讯网页版微信的处理还是有区别（太乱看不懂……）。