### PR TITLE
获取初始化返回的群聊的成员信息

### DIFF
--- a/src/wechat.js
+++ b/src/wechat.js
@@ -146,8 +146,17 @@ class Wechat extends WechatCore {
       // this.getContact() 这个接口返回通讯录中的联系人（包括已保存的群聊）
       // 临时的群聊会话在初始化的接口中可以获取，因此这里也需要更新一遍 contacts
       // 否则后面可能会拿不到某个临时群聊的信息
-      this.updateContacts(data.ContactList)
-
+      let emptyGroup = data.ContractList.filter(contact => contact.UserName.startsWith('@@'))
+      if (emptyGroup.length != 0) {
+        this.batchGetContact(emptyGroup)
+        .then(_contacts => {
+          data.ContractList = data.ContractList.concat(_contacts || []) 
+          this.updateContacts(data.ContactList)
+        })        
+      } else {
+        this.updateContacts(data.ContactList)
+      }
+      
       this.notifyMobile()
       .catch(err => this.emit('error', err))
       this._getContact()


### PR DESCRIPTION
初始化返回的群联系人 MemberList 里的 NickName 为空，导致 message.Content 只显示了成员的会话 ID。