### PR TITLE
fix: 修复群消息转发失败

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -793,7 +793,7 @@ export default class WechatCore {
         'Msg': {
           'Type': msg.MsgType,
           'MediaId': '',
-          'Content': msg.Content.replace(/&lt;/g, '<').replace(/&gt;/g, '>'),
+          'Content': msg.Content.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/^.*:\n/,''),
           'FromUserName': this.user.UserName,
           'ToUserName': to,
           'LocalID': clientMsgId,


### PR DESCRIPTION
当对群消息转发时失败，因为群消息的Content已经被处理过，带有发消息人，需要去除掉，否则图片或者其他消息都无法转发成功

<img width="704" alt="image" src="https://user-images.githubusercontent.com/20028566/205437152-a7857bcf-d08c-4afe-addc-0b680d19e53b.png">
